### PR TITLE
Update ::set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/build-app.yaml
+++ b/.github/workflows/build-app.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: set version
         id: set-version
-        run: echo ::set-output name=version::"$(date '+%Y-%m-%d')-$(git --no-pager log -1 --pretty=%h)"
+        run: echo "version=$(date '+%Y-%m-%d')-$(git --no-pager log -1 --pretty=%h)" >> $GITHUB_OUTPUT
 
   build-and-push:
     name: Build and push


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/