### PR TITLE
Return isAdmin with html responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ local-online:
 	  --knelm-image=europe-west1-docker.pkg.dev/knada-gcp/knorten/knelm:v9 \
 	  --db-conn-string=postgres://postgres:postgres@localhost:5432/knorten \
 	  --airflow-egress-netpol=./.default-egress-airflow-worker.yaml\
+	  --admin-group=nada@nav.no \
 	  --session-key online-session
 
 local:
@@ -47,6 +48,7 @@ local:
 	  --in-cluster=false \
 	  --knelm-image=europe-west1-docker.pkg.dev/knada-gcp/knorten/knelm:v9 \
 	  --db-conn-string=postgres://postgres:postgres@localhost:5432/knorten \
+	  --admin-group=nada@nav.no \
 	  --session-key offline-session
 
 generate-sql:

--- a/e2etests/main_test.go
+++ b/e2etests/main_test.go
@@ -112,6 +112,7 @@ func TestMain(m *testing.M) {
 		true,
 		"1.8.0",
 		"2.0.0",
+		"nada@nav.no",
 		"session",
 		logrus.NewEntry(logrus.StandardLogger()))
 	if err != nil {

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -42,6 +42,8 @@ spec:
             value: /root/.config/netpol/default-egress-airflow-worker.yaml
           - name: "KNELM_IMAGE"
             value: europe-west1-docker.pkg.dev/knada-gcp/knada/knelm:2023-03-15-3c6e024
+          - name: ADMIN_GROUP
+            value: nada@nav.no
         envFrom:
         - secretRef:
             name: knorten

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ type Config struct {
 	AirflowChartVersion string
 	JupyterChartVersion string
 	AirflowEgressNetPol string
+	AdminGroup          string
 	SessionKey          string
 }
 
@@ -54,6 +55,7 @@ func main() {
 	flag.StringVar(&cfg.KnelmImage, "knelm-image", os.Getenv("KNELM_IMAGE"), "Knelm image")
 	flag.StringVar(&cfg.AirflowChartVersion, "airflow-chart-version", os.Getenv("AIRFLOW_CHART_VERSION"), "The chart version for airflow")
 	flag.StringVar(&cfg.JupyterChartVersion, "jupyter-chart-version", os.Getenv("JUPYTER_CHART_VERSION"), "The chart version for jupyter")
+	flag.StringVar(&cfg.AdminGroup, "admin-group", os.Getenv("ADMIN_GROUP"), "Email of admin group used to authenticate Knorten administrators")
 	flag.StringVar(&cfg.AirflowEgressNetPol, "airflow-egress-netpol", os.Getenv("AIRFLOW_EGRESS_NETPOL"), "Path to the Airflow default egress netpol")
 	flag.StringVar(&cfg.SessionKey, "session-key", os.Getenv("SESSION_KEY"), "The session key for Knorten")
 	flag.Parse()
@@ -81,7 +83,7 @@ func main() {
 		go imageUpdater.Run(imageUpdaterFrequency)
 	}
 
-	router, err := api.New(repo, azureClient, googleClient, k8sClient, cryptClient, cfg.DryRun, cfg.AirflowChartVersion, cfg.JupyterChartVersion, cfg.SessionKey, log.WithField("subsystem", "api"))
+	router, err := api.New(repo, azureClient, googleClient, k8sClient, cryptClient, cfg.DryRun, cfg.AirflowChartVersion, cfg.JupyterChartVersion, cfg.SessionKey, cfg.AdminGroup, log.WithField("subsystem", "api"))
 	if err != nil {
 		log.WithError(err).Fatal("creating api")
 		return

--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -56,11 +56,9 @@ func (a *API) setupAdminRoutes() {
 			}
 		}
 
-		c.HTML(http.StatusOK, "admin/index", gin.H{
-			"loggedIn": a.isLoggedIn(c),
-			"current":  "admin",
-			"errors":   flashes,
-			"teams":    teamApps,
+		a.htmlResponseWrapper(c, http.StatusOK, "admin/index", gin.H{
+			"errors": flashes,
+			"teams":  teamApps,
 		})
 	})
 
@@ -91,12 +89,10 @@ func (a *API) setupAdminRoutes() {
 			return
 		}
 
-		c.HTML(http.StatusOK, "admin/chart", gin.H{
-			"loggedIn": a.isLoggedIn(c),
-			"current":  "admin",
-			"values":   values,
-			"errors":   flashes,
-			"chart":    string(chartType),
+		a.htmlResponseWrapper(c, http.StatusOK, "admin/chart", gin.H{
+			"values": values,
+			"errors": flashes,
+			"chart":  string(chartType),
 		})
 	})
 
@@ -166,9 +162,7 @@ func (a *API) setupAdminRoutes() {
 			return
 		}
 
-		c.HTML(http.StatusOK, "admin/confirm", gin.H{
-			"loggedIn":      a.isLoggedIn(c),
-			"current":       "admin",
+		a.htmlResponseWrapper(c, http.StatusOK, "admin/confirm", gin.H{
 			"changedValues": changedValues,
 			"chart":         string(chartType),
 		})

--- a/pkg/api/chart.go
+++ b/pkg/api/chart.go
@@ -68,11 +68,10 @@ func (a *API) setupChartRoutes() {
 			return
 		}
 
-		c.HTML(http.StatusOK, fmt.Sprintf("charts/%v", chartType), gin.H{
-			"loggedIn": a.isLoggedIn(c),
-			"team":     team,
-			"form":     form,
-			"errors":   flashes,
+		a.htmlResponseWrapper(c, http.StatusOK, fmt.Sprintf("charts/%v", chartType), gin.H{
+			"team":   team,
+			"form":   form,
+			"errors": flashes,
 		})
 	})
 
@@ -176,8 +175,7 @@ func (a *API) setupChartRoutes() {
 			return
 		}
 
-		c.HTML(http.StatusOK, fmt.Sprintf("charts/%v", chartType), gin.H{
-			"loggedIn":              a.isLoggedIn(c),
+		a.htmlResponseWrapper(c, http.StatusOK, fmt.Sprintf("charts/%v", chartType), gin.H{
 			"team":                  slug,
 			"pending_jupyterhub":    team.PendingJupyterUpgrade,
 			"pending_airflow":       team.PendingAirflowUpgrade,

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -39,10 +39,9 @@ func (a *API) setupTeamRoutes() {
 			return
 		}
 
-		c.HTML(http.StatusOK, "team/new", gin.H{
-			"loggedIn": a.isLoggedIn(c),
-			"form":     form,
-			"errors":   flashes,
+		a.htmlResponseWrapper(c, http.StatusOK, "team/new", gin.H{
+			"form":   form,
+			"errors": flashes,
 		})
 	})
 
@@ -85,10 +84,9 @@ func (a *API) setupTeamRoutes() {
 			a.log.WithError(err).Error("problem saving session")
 			return
 		}
-		c.HTML(http.StatusOK, "team/edit", gin.H{
-			"loggedIn": a.isLoggedIn(c),
-			"team":     team,
-			"errors":   flashes,
+		a.htmlResponseWrapper(c, http.StatusOK, "team/edit", gin.H{
+			"team":   team,
+			"errors": flashes,
 		})
 	})
 

--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -25,8 +25,7 @@ func (a *API) setupUserRoutes() {
 		}
 
 		services, err := a.repo.ServicesForUser(c, user.Email)
-		c.HTML(http.StatusOK, "oversikt/index", gin.H{
-			"loggedIn": a.isLoggedIn(c),
+		a.htmlResponseWrapper(c, http.StatusOK, "oversikt/index", gin.H{
 			"errors":   err,
 			"flashes":  flashes,
 			"services": services,

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -30,6 +30,7 @@ type Session struct {
 	AccessToken string
 	Token       string
 	Expires     time.Time
+	IsAdmin     bool
 }
 
 type Azure struct {
@@ -154,7 +155,7 @@ func (a *Azure) GroupsForUser(token, email string) ([]MemberOfGroup, error) {
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %v", bearerToken))
 
-	var httpClient = &http.Client{
+	httpClient := &http.Client{
 		Timeout: time.Second * 10,
 	}
 
@@ -209,7 +210,7 @@ func (a *Azure) getBearerTokenOnBehalfOfUser(token string) (string, error) {
 		return "", err
 	}
 
-	var httpClient = &http.Client{
+	httpClient := &http.Client{
 		Timeout: time.Second * 10,
 	}
 

--- a/pkg/database/gensql/models.go
+++ b/pkg/database/gensql/models.go
@@ -80,6 +80,7 @@ type Session struct {
 	Name        string
 	Created     time.Time
 	Expires     time.Time
+	IsAdmin     bool
 }
 
 type Team struct {

--- a/pkg/database/gensql/sessions.sql.go
+++ b/pkg/database/gensql/sessions.sql.go
@@ -16,13 +16,15 @@ INSERT INTO "sessions" (
     "email",
     "token",
     "access_token",
-    "expires"
+    "expires",
+    "is_admin"
 ) VALUES (
     $1,
     $2,
     $3,
     $4,
-    $5
+    $5,
+    $6
 )
 `
 
@@ -32,6 +34,7 @@ type SessionCreateParams struct {
 	Token       string
 	AccessToken string
 	Expires     time.Time
+	IsAdmin     bool
 }
 
 func (q *Queries) SessionCreate(ctx context.Context, arg SessionCreateParams) error {
@@ -41,6 +44,7 @@ func (q *Queries) SessionCreate(ctx context.Context, arg SessionCreateParams) er
 		arg.Token,
 		arg.AccessToken,
 		arg.Expires,
+		arg.IsAdmin,
 	)
 	return err
 }
@@ -57,7 +61,7 @@ func (q *Queries) SessionDelete(ctx context.Context, token string) error {
 }
 
 const sessionGet = `-- name: SessionGet :one
-SELECT token, access_token, email, name, created, expires
+SELECT token, access_token, email, name, created, expires, is_admin
 FROM "sessions"
 WHERE token = $1
 AND expires > now()
@@ -73,6 +77,7 @@ func (q *Queries) SessionGet(ctx context.Context, token string) (Session, error)
 		&i.Name,
 		&i.Created,
 		&i.Expires,
+		&i.IsAdmin,
 	)
 	return i, err
 }

--- a/pkg/database/migrations/009_session_isadmin.sql
+++ b/pkg/database/migrations/009_session_isadmin.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE "sessions" ADD COLUMN "is_admin" BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE "sessions" DROP COLUMN "is_admin";

--- a/pkg/database/queries/sessions.sql
+++ b/pkg/database/queries/sessions.sql
@@ -4,13 +4,15 @@ INSERT INTO "sessions" (
     "email",
     "token",
     "access_token",
-    "expires"
+    "expires",
+    "is_admin"
 ) VALUES (
     @name,
     @email,
     @token,
     @access_token,
-    @expires
+    @expires,
+    @is_admin
 );
 
 -- name: SessionGet :one

--- a/pkg/database/sessions.go
+++ b/pkg/database/sessions.go
@@ -17,6 +17,7 @@ func (r *Repo) SessionCreate(ctx context.Context, session *auth.Session) error {
 		Token:       session.Token,
 		AccessToken: session.AccessToken,
 		Expires:     session.Expires,
+		IsAdmin:     session.IsAdmin,
 	})
 }
 
@@ -32,6 +33,7 @@ func (r *Repo) SessionGet(ctx context.Context, token string) (*auth.Session, err
 		AccessToken: dbSession.AccessToken,
 		Token:       dbSession.Token,
 		Expires:     dbSession.Expires,
+		IsAdmin:     dbSession.IsAdmin,
 	}, nil
 }
 

--- a/templates/shared/head.tmpl
+++ b/templates/shared/head.tmpl
@@ -23,11 +23,11 @@
                 <span class="text-">by nada</span>
             </a>
             <nav class="flex items-center gap-2">
-                <a href="/oversikt" class="navds-button navds-button--small navds-button--secondary bg-initial">Teams</a>
-                {{ if eq .current "admin" }}
+                {{ if .isAdmin }}
                     <a href="/admin" class="navds-button navds-button--small navds-button--secondary">Admin</a>
                 {{ end }}
                 {{ if .loggedIn }}
+                    <a href="/oversikt" class="navds-button navds-button--small navds-button--secondary bg-initial">Teams</a>
                     <a href="/oauth2/logout" class="navds-button navds-button--small navds-button--secondary bg-initial">Logg ut</a>
                 {{ else }}
                     <a href="/oauth2/login" class="navds-button navds-button--small navds-button--secondary bg-initial">Logg inn</a>


### PR DESCRIPTION
- wrap all html responses in a common wrapper where loggedIn and isAdmin statuses are always appended to the values map
- store isAdmin flag for user sessions in db
- inject admin group from config