### PR TITLE
Team owners

### DIFF
--- a/e2etests/admin_api_test.go
+++ b/e2etests/admin_api_test.go
@@ -92,7 +92,8 @@ func TestAdminAPI(t *testing.T) {
 				team.ID: map[string]any{
 					"ID":    team.ID,
 					"Slug":  teamName,
-					"Users": []string{"dummy@nav.no"},
+					"Owner": "dummy@nav.no",
+					"Users": []string{"annenbruker@nav.no"},
 					"Apps":  []string{"jupyterhub", "airflow"},
 				},
 			},

--- a/e2etests/charts_api_test.go
+++ b/e2etests/charts_api_test.go
@@ -490,10 +490,14 @@ func TestChartsAPI(t *testing.T) {
 			t.Fatalf("Content-Type header is %v, should be %v", resp.Header.Get("Content-Type"), htmlContentType)
 		}
 	})
+
+	if err := cleanupTeamAndApps(testTeam); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func prepareChartTests(ctx context.Context, teamName string) error {
-	data := url.Values{"team": {teamName}, "users[]": {"user.userson@nav.no"}, "apiaccess": {""}}
+	data := url.Values{"team": {teamName}, "owner": {"dummy@nav.no"}, "users[]": {"user.userson@nav.no"}, "apiaccess": {""}}
 	resp, err := server.Client().PostForm(fmt.Sprintf("%v/team/new", server.URL), data)
 	if err != nil {
 		return err

--- a/e2etests/compute_api_test.go
+++ b/e2etests/compute_api_test.go
@@ -21,7 +21,7 @@ func TestComputeAPI(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := repo.TeamCreate(ctx, testTeam+"-1234", testTeam, []string{"bruker.en@nav.no", "bruker.to@nav.no"}, false); err != nil {
+	if err := repo.TeamCreate(ctx, testTeam+"-1234", testTeam, "bruker.en@nav.no", []string{"bruker.en@nav.no", "bruker.to@nav.no"}, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/e2etests/main_test.go
+++ b/e2etests/main_test.go
@@ -168,7 +168,7 @@ func replaceGeneratedValues(expected []byte, teamName string) ([]byte, error) {
 }
 
 func createTeamAndApps(teamName string) error {
-	data := url.Values{"team": {teamName}, "users[]": {"dummy@nav.no"}, "apiaccess": {""}}
+	data := url.Values{"team": {teamName}, "owner": {"dummy@nav.no"}, "users[]": {"annenbruker@nav.no"}, "apiaccess": {""}}
 	resp, err := server.Client().PostForm(fmt.Sprintf("%v/team/new", server.URL), data)
 	if err != nil {
 		return fmt.Errorf("creating team: %v", err)

--- a/e2etests/teams_api_test.go
+++ b/e2etests/teams_api_test.go
@@ -44,7 +44,9 @@ func TestTeamsAPI(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expected, err := createExpectedHTML("team/new", nil)
+		expected, err := createExpectedHTML("team/new", map[string]any{
+			"owner": "dummy@nav.no",
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -60,7 +62,7 @@ func TestTeamsAPI(t *testing.T) {
 
 	teamMembers := []string{"first.sirname@nav.no", "second.sirname@nav.no"}
 	t.Run("create new team", func(t *testing.T) {
-		data := url.Values{"team": {testTeam}, "users[]": teamMembers, "apiaccess": {""}}
+		data := url.Values{"team": {testTeam}, "owner": {"dummy@nav.no"}, "users[]": teamMembers, "apiaccess": {""}}
 		resp, err := server.Client().PostForm(fmt.Sprintf("%v/team/new", server.URL), data)
 		if err != nil {
 			t.Fatal(err)
@@ -100,7 +102,7 @@ func TestTeamsAPI(t *testing.T) {
 
 	t.Run("create new team with api access", func(t *testing.T) {
 		apiAccessTeam := "apiteam"
-		data := url.Values{"team": {apiAccessTeam}, "users[]": teamMembers, "apiaccess": {"on"}}
+		data := url.Values{"team": {apiAccessTeam}, "owner": {"dummy@nav.no"}, "users[]": teamMembers, "apiaccess": {"on"}}
 		resp, err := server.Client().PostForm(fmt.Sprintf("%v/team/new", server.URL), data)
 		if err != nil {
 			t.Fatal(err)
@@ -117,6 +119,10 @@ func TestTeamsAPI(t *testing.T) {
 
 		if !team.ApiAccess {
 			t.Fatalf("team api access should be %v, got %v", true, team.ApiAccess)
+		}
+
+		if err := cleanupTeamAndApps(apiAccessTeam); err != nil {
+			t.Fatal(err)
 		}
 	})
 
@@ -154,6 +160,7 @@ func TestTeamsAPI(t *testing.T) {
 			"team": gensql.TeamGetRow{
 				ID:    team.ID,
 				Slug:  testTeam,
+				Owner: "dummy@nav.no",
 				Users: teamMembers,
 			},
 		})
@@ -189,7 +196,7 @@ func TestTeamsAPI(t *testing.T) {
 	teamMembers = append(teamMembers, "third.sirname@nav.no")
 
 	t.Run("update team", func(t *testing.T) {
-		data := url.Values{"team": {testTeam}, "users[]": teamMembers, "apiaccess": {"on"}}
+		data := url.Values{"team": {testTeam}, "owner": {"dummy@nav.no"}, "users[]": teamMembers, "apiaccess": {"on"}}
 		resp, err := server.Client().PostForm(fmt.Sprintf("%v/team/%v/edit", server.URL, testTeam), data)
 		if err != nil {
 			t.Fatal(err)

--- a/e2etests/testdata/yaml/airflow_new.yaml
+++ b/e2etests/testdata/yaml/airflow_new.yaml
@@ -697,7 +697,7 @@ webserver:
     username: admin
   env:
   - name: AIRFLOW_USERS
-    value: user.userson@nav.no
+    value: user.userson@nav.no,dummy@nav.no
   extraContainers:
   - args:
     - navikt/repo

--- a/e2etests/testdata/yaml/airflow_updated.yaml
+++ b/e2etests/testdata/yaml/airflow_updated.yaml
@@ -697,7 +697,7 @@ webserver:
     username: admin
   env:
   - name: AIRFLOW_USERS
-    value: user.userson@nav.no
+    value: user.userson@nav.no,dummy@nav.no
   - name: AIRFLOW__API__AUTH_BACKENDS
     value: airflow.api.auth.backend.session,airflow.api.auth.backend.basic_auth
   extraContainers:

--- a/e2etests/testdata/yaml/jupyterhub_new.yaml
+++ b/e2etests/testdata/yaml/jupyterhub_new.yaml
@@ -26,8 +26,10 @@ hub:
     Authenticator:
       admin_users:
       - user.userson@nav.no
+      - dummy@nav.no
       allowed_users:
       - user.userson@nav.no
+      - dummy@nav.no
     AzureAdOAuthenticator:
       oauth_callback_url: https://chartteam.jupyter.knada.io/hub/oauth_callback
     JupyterHub:

--- a/e2etests/testdata/yaml/jupyterhub_updated.yaml
+++ b/e2etests/testdata/yaml/jupyterhub_updated.yaml
@@ -26,8 +26,10 @@ hub:
     Authenticator:
       admin_users:
       - user.userson@nav.no
+      - dummy@nav.no
       allowed_users:
       - user.userson@nav.no
+      - dummy@nav.no
     AzureAdOAuthenticator:
       oauth_callback_url: https://chartteam.jupyter.knada.io/hub/oauth_callback
     JupyterHub:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -63,7 +63,7 @@ func New(repo *database.Repo, azureClient *auth.Azure, googleClient *google.Goog
 		dryRun:       dryRun,
 	}
 
-	api.teamClient = team.NewClient(repo, googleClient, k8sClient, api.chartClient, log)
+	api.teamClient = team.NewClient(repo, googleClient, k8sClient, api.chartClient, azureClient, dryRun, log.WithField("subsystem", "teamClient"))
 
 	session, err := repo.NewSessionStore(sessionKey)
 	if err != nil {

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -93,7 +93,7 @@ func (a *API) setupTeamRoutes() {
 			return
 		}
 
-		// Remove owner from user slice for edit team form
+		// Avoid duplicating owner as a user in edit form
 		team.Users = slices.Filter(nil, team.Users, func(s string) bool {
 			return s != team.Owner
 		})

--- a/pkg/api/team.go
+++ b/pkg/api/team.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
+	"github.com/nais/knorten/pkg/auth"
 	"github.com/nais/knorten/pkg/team"
 )
 
@@ -39,8 +40,22 @@ func (a *API) setupTeamRoutes() {
 			return
 		}
 
+		user, exists := c.Get("user")
+		if !exists {
+			a.log.Errorf("unable to identify logged in user when creating team")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "unable to identify logged in user when creating team"})
+			return
+		}
+		owner, ok := user.(*auth.User)
+		if !ok {
+			a.log.Errorf("unable to identify logged in user when creating team, user object %v", user)
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "unable to identify logged in user when creating team"})
+			return
+		}
+
 		a.htmlResponseWrapper(c, http.StatusOK, "team/new", gin.H{
 			"form":   form,
+			"owner":  owner.Email,
 			"errors": flashes,
 		})
 	})
@@ -77,6 +92,19 @@ func (a *API) setupTeamRoutes() {
 			return
 		}
 
+		user, exists := c.Get("user")
+		if !exists {
+			a.log.Errorf("unable to identify logged in user when creating team")
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "unable to identify logged in user when creating team"})
+			return
+		}
+		owner, ok := user.(*auth.User)
+		if !ok {
+			a.log.Errorf("unable to identify logged in user when creating team, user object %v", user)
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"message": "unable to identify logged in user when creating team"})
+			return
+		}
+
 		session := sessions.Default(c)
 		flashes := session.Flashes()
 		err = session.Save()
@@ -86,6 +114,7 @@ func (a *API) setupTeamRoutes() {
 		}
 		a.htmlResponseWrapper(c, http.StatusOK, "team/edit", gin.H{
 			"team":   team,
+			"owner":  owner.Email,
 			"errors": flashes,
 		})
 	})

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -12,7 +12,6 @@ import (
 	"github.com/coreos/go-oidc"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/endpoints"
 )
@@ -181,7 +180,7 @@ func (a *Azure) GroupsForUser(token, email string) ([]MemberOfGroup, error) {
 
 func contains(groups []MemberOfGroup, email string) bool {
 	for _, group := range groups {
-		if strings.ToLower(group.Mail) == strings.ToLower(email) {
+		if strings.EqualFold(group.Mail, email) {
 			return true
 		}
 	}
@@ -229,6 +228,6 @@ func (a *Azure) getBearerTokenOnBehalfOfUser(token string) (string, error) {
 		return "", err
 	}
 
-	log.Debugf("Successfully retrieved on-behalf-of token")
+	logrus.Debugf("Successfully retrieved on-behalf-of token")
 	return tokenResponse.AccessToken, nil
 }

--- a/pkg/auth/azure.go
+++ b/pkg/auth/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -59,10 +60,15 @@ type MemberOfGroup struct {
 	GroupTypes  []string `json:"groupTypes"`
 }
 
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
 var ErrAzureTokenExpired = fmt.Errorf("token expired")
 
 const (
 	AzureGraphMemberOfEndpoint = "https://graph.microsoft.com/v1.0/me/memberOf/microsoft.graph.group?$select=mail"
+	AzureUsersEndpoint         = "https://graph.microsoft.com/v1.0/users"
 )
 
 func New(dryRun bool, clientID, clientSecret, tenantID, hostname string, log *logrus.Entry) *Azure {
@@ -147,6 +153,53 @@ func (a *Azure) ValidateUser(certificates map[string]CertificateList, token stri
 	}, nil
 }
 
+func (a *Azure) UserExistsInAzureAD(user string) error {
+	type usersResponse struct {
+		Value []struct {
+			Email string `json:"userPrincipalName"`
+		} `json:"value"`
+	}
+
+	token, err := a.getBearerTokenForApplication()
+	if err != nil {
+		return err
+	}
+
+	r, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%v?$filter=startswith(userPrincipalName,'%v')", AzureUsersEndpoint, user), nil)
+	if err != nil {
+		return err
+	}
+	r.Header.Add("Authorization", fmt.Sprintf("Bearer %v", token))
+
+	httpClient := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	res, err := httpClient.Do(r)
+	if err != nil {
+		return err
+	}
+
+	resBytes, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	var users usersResponse
+	if err := json.Unmarshal(resBytes, &users); err != nil {
+		return err
+	}
+
+	switch len(users.Value) {
+	case 0:
+		return fmt.Errorf("no user exists in aad with email %v", user)
+	case 1:
+		return nil
+	default:
+		return fmt.Errorf("multiple users exist in aad for email %v", user)
+	}
+}
+
 func (a *Azure) GroupsForUser(token, email string) ([]MemberOfGroup, error) {
 	bearerToken, err := a.getBearerTokenOnBehalfOfUser(token)
 	if err != nil {
@@ -196,11 +249,36 @@ func (a *Azure) UserInGroup(token string, userEmail, groupEmail string) (bool, e
 	return contains(groups, groupEmail), nil
 }
 
-func (a *Azure) getBearerTokenOnBehalfOfUser(token string) (string, error) {
-	type TokenResponse struct {
-		AccessToken string `json:"access_token"`
+func (a *Azure) getBearerTokenForApplication() (string, error) {
+	form := url.Values{}
+	form.Add("client_id", a.clientID)
+	form.Add("client_secret", a.clientSecret)
+	form.Add("scope", "https://graph.microsoft.com/.default")
+	form.Add("grant_type", "client_credentials")
+
+	req, err := http.NewRequest(http.MethodPost, endpoints.AzureAD(a.tenantID).TokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
 	}
 
+	httpClient := &http.Client{
+		Timeout: time.Second * 10,
+	}
+
+	response, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	var tokenResponse TokenResponse
+	if err := json.NewDecoder(response.Body).Decode(&tokenResponse); err != nil {
+		return "", err
+	}
+
+	return tokenResponse.AccessToken, nil
+}
+
+func (a *Azure) getBearerTokenOnBehalfOfUser(token string) (string, error) {
 	form := url.Values{}
 	form.Add("client_id", a.clientID)
 	form.Add("client_secret", a.clientSecret)

--- a/pkg/database/gensql/models.go
+++ b/pkg/database/gensql/models.go
@@ -141,4 +141,5 @@ type Team struct {
 	PendingAirflowUpgrade bool
 	RestrictAirflowEgress bool
 	ApiAccess             bool
+	Owner                 string
 }

--- a/pkg/database/migrations/011_team_owner.sql
+++ b/pkg/database/migrations/011_team_owner.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE teams ADD COLUMN "owner" TEXT;
+UPDATE teams t SET owner = (SELECT users[1] FROM teams where id = t.id), users = (SELECT users[2:] FROM teams WHERE id = t.id);
+ALTER TABLE teams ALTER COLUMN "owner" SET NOT NULL;
+
+-- +goose Down
+ALTER TABLE teams DROP COLUMN "owner";

--- a/pkg/database/migrations/011_team_owner.sql
+++ b/pkg/database/migrations/011_team_owner.sql
@@ -4,4 +4,5 @@ UPDATE teams t SET owner = (SELECT users[1] FROM teams where id = t.id), users =
 ALTER TABLE teams ALTER COLUMN "owner" SET NOT NULL;
 
 -- +goose Down
+UPDATE teams t SET users = array_prepend(t.owner, t.users);
 ALTER TABLE teams DROP COLUMN "owner";

--- a/pkg/database/queries/teams.sql
+++ b/pkg/database/queries/teams.sql
@@ -1,6 +1,6 @@
 -- name: TeamCreate :exec
-INSERT INTO teams ("id", "users", "slug", "api_access")
-VALUES (@id, @users, @slug, @api_access);
+INSERT INTO teams ("id", "users", "slug", "api_access", "owner")
+VALUES (@id, @users, @slug, @api_access, @owner);
 
 -- name: TeamUpdate :exec
 UPDATE teams
@@ -11,10 +11,10 @@ WHERE id = @id;
 -- name: TeamsForUserGet :many
 SELECT id, slug
 FROM teams
-WHERE @email::TEXT = ANY ("users");
+WHERE "owner" = @email OR @email::TEXT = ANY ("users");
 
 -- name: TeamGet :one
-SELECT id, users, slug, pending_jupyter_upgrade, pending_airflow_upgrade, api_access, restrict_airflow_egress
+SELECT id, "owner", users, slug, pending_jupyter_upgrade, pending_airflow_upgrade, api_access, restrict_airflow_egress
 FROM teams
 WHERE slug = @slug;
 

--- a/pkg/database/teams.go
+++ b/pkg/database/teams.go
@@ -26,7 +26,12 @@ func (r *Repo) TeamUpdate(ctx context.Context, team string, users []string, apiA
 }
 
 func (r *Repo) TeamGet(ctx context.Context, slug string) (gensql.TeamGetRow, error) {
-	return r.querier.TeamGet(ctx, slug)
+	team, err := r.querier.TeamGet(ctx, slug)
+	if err != nil {
+		return gensql.TeamGetRow{}, err
+	}
+	team.Users = append(team.Users, team.Owner)
+	return team, nil
 }
 
 func (r *Repo) TeamDelete(ctx context.Context, team string) error {

--- a/pkg/database/teams.go
+++ b/pkg/database/teams.go
@@ -7,12 +7,13 @@ import (
 	"github.com/nais/knorten/pkg/database/gensql"
 )
 
-func (r *Repo) TeamCreate(ctx context.Context, team, slug string, users []string, apiAccess bool) error {
+func (r *Repo) TeamCreate(ctx context.Context, team, slug, owner string, users []string, apiAccess bool) error {
 	return r.querier.TeamCreate(ctx, gensql.TeamCreateParams{
 		ID:        team,
 		Users:     stringSliceToLower(users),
 		Slug:      slug,
 		ApiAccess: apiAccess,
+		Owner:     owner,
 	})
 }
 

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -39,7 +39,8 @@ func NewClient(repo *database.Repo, googleClient *google.Google, k8sClient *k8s.
 
 type Form struct {
 	Slug      string   `form:"team" binding:"required,validTeamName"`
-	Users     []string `form:"users[]" binding:"required,validEmail"`
+	Owner     string   `form:"owner" binding:"required"`
+	Users     []string `form:"users[]" binding:"validEmail"`
 	APIAccess string   `form:"apiaccess"`
 }
 
@@ -61,7 +62,7 @@ func (c Client) Create(ctx *gin.Context) error {
 
 	teamID := createTeamID(form.Slug)
 
-	if err := c.repo.TeamCreate(ctx, teamID, form.Slug, removeEmptyUsers(form.Users), form.APIAccess == "on"); err != nil {
+	if err := c.repo.TeamCreate(ctx, teamID, form.Slug, form.Owner, removeEmptyUsers(form.Users), form.APIAccess == "on"); err != nil {
 		return err
 	}
 

--- a/pkg/team/validators.go
+++ b/pkg/team/validators.go
@@ -16,8 +16,15 @@ var ValidateTeamName validator.Func = func(fl validator.FieldLevel) bool {
 }
 
 var ValidateTeamUsers validator.Func = func(fl validator.FieldLevel) bool {
-	users := fl.Field().Interface().([]string)
+	users, ok := fl.Field().Interface().([]string)
+	if !ok {
+		return false
+	}
+
 	for _, user := range users {
+		if user == "" {
+			continue
+		}
 		_, err := mail.ParseAddress(user)
 		if err != nil {
 			return false

--- a/templates/admin/index.tmpl
+++ b/templates/admin/index.tmpl
@@ -20,6 +20,10 @@
                 <div class="p-4">
                     <h4 class="text-xl font-bold">{{ .ID }}</h4>
                     {{ template "admin/row" . }}
+                    <h5 class="font-bold">Eier</h5>
+                    <ul class="list-disc ml-4">
+                        {{ .Owner }}
+                    </ul>
                     <h5 class="font-bold">Brukere</h5>
                     <ul class="list-disc ml-4">
                         {{ range .Users }}

--- a/templates/team/edit.tmpl
+++ b/templates/team/edit.tmpl
@@ -22,6 +22,13 @@
             {{ end }}
 
             <form action="" method="POST" class="flex flex-col gap-4 w-80">
+                <div class="">
+                    <label for="owner" class="navds-form-field__label navds-label">Eier</label>
+                    <input style="background-color:#AAAFB4" readonly type="text" name="owner" id="owner" value="{{ .owner }}"
+                           placeholder="Eieren av teamet"
+                           class="navds-text-field__input navds-body-short navds-body-medium"
+                    />
+                </div>
                 <fieldset id="users">
                     <legend class="navds-form-field__label navds-label">Brukere</legend>
                     <button type="button" class="mb-4 navds-button navds-button--secondary navds-button--small"

--- a/templates/team/edit.tmpl
+++ b/templates/team/edit.tmpl
@@ -24,7 +24,7 @@
             <form action="" method="POST" class="flex flex-col gap-4 w-80">
                 <div class="">
                     <label for="owner" class="navds-form-field__label navds-label">Eier</label>
-                    <input style="background-color:#AAAFB4" readonly type="text" name="owner" id="owner" value="{{ .owner }}"
+                    <input style="background-color:#AAAFB4" readonly type="text" name="owner" id="owner" value="{{ .team.Owner }}"
                            placeholder="Eieren av teamet"
                            class="navds-text-field__input navds-body-short navds-body-medium"
                     />

--- a/templates/team/new.tmpl
+++ b/templates/team/new.tmpl
@@ -14,6 +14,13 @@
                            class="navds-text-field__input navds-body-short navds-body-medium"
                     />
                 </div>
+                <div class="">
+                    <label for="owner" class="navds-form-field__label navds-label">Eier</label>
+                    <input style="background-color:#AAAFB4" readonly type="text" name="owner" id="owner" value="{{ .owner }}"
+                           placeholder="Eieren av teamet"
+                           class="navds-text-field__input navds-body-short navds-body-medium"
+                    />
+                </div>
                 <fieldset id="users">
                     <legend class="navds-form-field__label navds-label">Brukere</legend>
                     <button type="button" class="mb-4 navds-button navds-button--secondary navds-button--small" onClick="addElement()">


### PR DESCRIPTION
Endringer i denne PRen:
- Lagt til obligatorisk owner for teams som defaulter til innlogget bruker som oppretter teamet. For team som allerede eksisterer vil database migrasjonen ta den første brukeren fra users listen (som var den som opprettet teamet i utgangspunktet) og sette som owner
- Lagt inn sperre for å hindre at folk oppretter team med samme slug som et som allerede eksisterer
- Sjekker mot azure ad alle brukere som legges i users listen (både ved opprettelse og oppdatering av team) og returnerer feil dersom brukeren(e) ikke finnes i aad
- Oppdatert tester for owner endringen