### PR TITLE
fix: jupyter values for sync triggered from team update or admin panel

### DIFF
--- a/pkg/api/admin.go
+++ b/pkg/api/admin.go
@@ -362,9 +362,6 @@ func (c *client) syncChartForAllTeams(ctx context.Context, chartType gensql.Char
 func (c *client) syncChart(ctx context.Context, teamID string, chartType gensql.ChartType) error {
 	switch chartType {
 	case gensql.ChartTypeJupyterhub:
-		// TODO: Dette er ikke implementert på chart.Jupyterhub siden, se TODO der.
-		return fmt.Errorf("chart type %v not implemented", chartType)
-
 		values := chart.JupyterConfigurableValues{
 			TeamID: teamID,
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,7 +23,7 @@ type client struct {
 	gcpZone      string
 }
 
-func New(repo *database.Repo, dryRun bool, clientID, clientSecret, tenantID, sessionKey, adminGroupEmail, gcpProject, gcpZone string, log *logrus.Entry) (*gin.Engine, error) {
+func New(repo *database.Repo, azureClient *auth.Azure, dryRun bool, sessionKey, adminGroupEmail, gcpProject, gcpZone string, log *logrus.Entry) (*gin.Engine, error) {
 	router := gin.New()
 
 	router.Use(gin.Recovery())
@@ -32,7 +32,7 @@ func New(repo *database.Repo, dryRun bool, clientID, clientSecret, tenantID, ses
 	})
 
 	api := client{
-		azureClient: auth.NewAzureClient(dryRun, clientID, clientSecret, tenantID, log.WithField("subsystem", "auth")),
+		azureClient: azureClient,
 		router:      router,
 		repo:        repo,
 		log:         log,
@@ -150,16 +150,4 @@ func (c *client) fetchAdminGroupID(adminGroupEmail string) error {
 
 	c.adminGroupID = id
 	return nil
-}
-
-func (c *client) convertEmailsToIdents(emails []string) ([]string, error) {
-	var idents []string
-	for _, e := range emails {
-		ident, err := c.azureClient.IdentForEmail(e)
-		if err != nil {
-			return nil, err
-		}
-		idents = append(idents, ident)
-	}
-	return idents, nil
 }

--- a/pkg/api/chart.go
+++ b/pkg/api/chart.go
@@ -349,18 +349,18 @@ func (c *client) getEditChart(ctx *gin.Context, teamSlug string, chartType gensq
 	var allowlist []string
 	switch chartType {
 	case gensql.ChartTypeJupyterhub:
-		chartObjects = &chart.JupyterConfigurableValues{}
+		chartObjects = chart.JupyterConfigurableValues{}
 		allowlist, err = c.getExistingAllowlist(ctx, team.ID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return nil, err
 		}
 	case gensql.ChartTypeAirflow:
-		chartObjects = &chart.AirflowConfigurableValues{}
+		chartObjects = chart.AirflowConfigurableValues{}
 	default:
 		return nil, fmt.Errorf("chart type %v is not supported", chartType)
 	}
 
-	err = c.repo.TeamConfigurableValuesGet(ctx, chartType, team.ID, chartObjects)
+	err = c.repo.TeamConfigurableValuesGet(ctx, chartType, team.ID, &chartObjects)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/chart.go
+++ b/pkg/api/chart.go
@@ -346,14 +346,9 @@ func (c *client) getEditChart(ctx *gin.Context, teamSlug string, chartType gensq
 	}
 
 	var chartObjects any
-	var allowlist []string
 	switch chartType {
 	case gensql.ChartTypeJupyterhub:
 		chartObjects = chart.JupyterConfigurableValues{}
-		allowlist, err = c.getExistingAllowlist(ctx, team.ID)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return nil, err
-		}
 	case gensql.ChartTypeAirflow:
 		chartObjects = chart.AirflowConfigurableValues{}
 	default:
@@ -369,6 +364,11 @@ func (c *client) getEditChart(ctx *gin.Context, teamSlug string, chartType gensq
 	switch chartType {
 	case gensql.ChartTypeJupyterhub:
 		jupyterhubValues := chartObjects.(*chart.JupyterConfigurableValues)
+		allowlist, err := c.getExistingAllowlist(ctx, team.ID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+
 		form = jupyterForm{
 			CPU:         jupyterhubValues.CPU,
 			Memory:      jupyterhubValues.Memory,

--- a/pkg/api/chart.go
+++ b/pkg/api/chart.go
@@ -287,7 +287,7 @@ func (c *client) newChart(ctx *gin.Context, teamSlug string, chartType gensql.Ch
 			return err
 		}
 
-		userIdents, err := c.convertEmailsToIdents(team.Users)
+		userIdents, err := c.azureClient.ConvertEmailsToIdents(team.Users)
 		if err != nil {
 			return err
 		}
@@ -404,7 +404,7 @@ func (c *client) editChart(ctx *gin.Context, teamSlug string, chartType gensql.C
 			return err
 		}
 
-		userIdents, err := c.convertEmailsToIdents(team.Users)
+		userIdents, err := c.azureClient.ConvertEmailsToIdents(team.Users)
 		if err != nil {
 			return err
 		}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -3,6 +3,7 @@ package chart
 import (
 	"context"
 
+	"github.com/nais/knorten/pkg/api/auth"
 	"github.com/nais/knorten/pkg/database"
 	"github.com/nais/knorten/pkg/database/gensql"
 	"github.com/nais/knorten/pkg/k8s"
@@ -13,6 +14,7 @@ import (
 type Client struct {
 	repo                *database.Repo
 	k8sClient           *kubernetes.Clientset
+	azureClient         *auth.Azure
 	dryRun              bool
 	chartVersionAirflow string
 	chartVersionJupyter string
@@ -20,7 +22,7 @@ type Client struct {
 	gcpRegion           string
 }
 
-func NewClient(repo *database.Repo, dryRun, inCluster bool, airflowChartVersion, jupyterChartVersion, gcpProject, gcpRegion string) (*Client, error) {
+func NewClient(repo *database.Repo, azureClient *auth.Azure, dryRun, inCluster bool, airflowChartVersion, jupyterChartVersion, gcpProject, gcpRegion string) (*Client, error) {
 	k8sClient, err := k8s.CreateClientset(dryRun, inCluster)
 	if err != nil {
 		return nil, err
@@ -28,6 +30,7 @@ func NewClient(repo *database.Repo, dryRun, inCluster bool, airflowChartVersion,
 
 	return &Client{
 		repo:                repo,
+		azureClient:         azureClient,
 		k8sClient:           k8sClient,
 		dryRun:              dryRun,
 		chartVersionJupyter: jupyterChartVersion,

--- a/pkg/chart/jupyterhub.go
+++ b/pkg/chart/jupyterhub.go
@@ -49,7 +49,10 @@ func (c Client) syncJupyter(ctx context.Context, configurableValues JupyterConfi
 		return err
 	}
 
-	values := c.jupyterMergeValues(team, configurableValues)
+	values, err := c.jupyterMergeValues(ctx, team, configurableValues)
+	if err != nil {
+		return err
+	}
 
 	chartValues, err := reflect.CreateChartValues(values)
 	if err != nil {
@@ -91,9 +94,12 @@ func jupyterReleaseName(namespace string) string {
 	return fmt.Sprintf("%v-%v", string(gensql.ChartTypeJupyterhub), namespace)
 }
 
-func (c Client) jupyterMergeValues(team gensql.TeamGetRow, configurableValues JupyterConfigurableValues) jupyterValues {
-	// TODO: Her må vi sjekke om configurableValues er tom, og hente fra databasen hvis det er tilfelle
-	// configurableValues er tom hvis den kommer fra team-endringer eller som en sync fra admin.
+func (c Client) jupyterMergeValues(ctx context.Context, team gensql.TeamGetRow, configurableValues JupyterConfigurableValues) (jupyterValues, error) {
+	if len(configurableValues.UserIdents) == 0 {
+		if err := c.getJupyterConfigurableValues(ctx, team, &configurableValues); err != nil {
+			return jupyterValues{}, err
+		}
+	}
 
 	var profileList string
 	if configurableValues.ImageName != "" {
@@ -120,5 +126,19 @@ func (c Client) jupyterMergeValues(team gensql.TeamGetRow, configurableValues Ju
 		KnadaTeamSecret:           fmt.Sprintf("projects/%v/secrets/%v", c.gcpProject, team.ID),
 		ProfileList:               profileList,
 		ExtraAnnotations:          allowList,
+	}, nil
+}
+
+func (c Client) getJupyterConfigurableValues(ctx context.Context, team gensql.TeamGetRow, configurableValues *JupyterConfigurableValues) error {
+	err := c.repo.TeamConfigurableValuesGet(ctx, gensql.ChartTypeJupyterhub, team.ID, configurableValues)
+	if err != nil {
+		return err
 	}
+
+	configurableValues.UserIdents, err = c.azureClient.ConvertEmailsToIdents(team.Users)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/events/dispatcher.go
+++ b/pkg/events/dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/nais/knorten/pkg/api/auth"
 	"github.com/nais/knorten/pkg/chart"
 	"github.com/nais/knorten/pkg/compute"
 	"github.com/nais/knorten/pkg/database"
@@ -106,13 +107,13 @@ func (e EventHandler) processWork(event gensql.Event, logger logger.Logger, form
 	return e.repo.EventSetStatus(e.context, event.ID, gensql.EventStatusCompleted)
 }
 
-func NewHandler(ctx context.Context, repo *database.Repo, gcpProject, gcpRegion, gcpZone, airflowChartVersion, jupyterChartVersion string, dryRun, inCluster bool, log *logrus.Entry) (EventHandler, error) {
+func NewHandler(ctx context.Context, repo *database.Repo, azureClient *auth.Azure, gcpProject, gcpRegion, gcpZone, airflowChartVersion, jupyterChartVersion string, dryRun, inCluster bool, log *logrus.Entry) (EventHandler, error) {
 	teamClient, err := team.NewClient(repo, gcpProject, gcpRegion, dryRun, inCluster)
 	if err != nil {
 		return EventHandler{}, err
 	}
 
-	chartClient, err := chart.NewClient(repo, dryRun, inCluster, airflowChartVersion, jupyterChartVersion, gcpProject, gcpRegion)
+	chartClient, err := chart.NewClient(repo, azureClient, dryRun, inCluster, airflowChartVersion, jupyterChartVersion, gcpProject, gcpRegion)
 	if err != nil {
 		return EventHandler{}, err
 	}

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -91,16 +91,14 @@ func (c Client) Update(ctx context.Context, team gensql.Team, log logger.Logger)
 		return true
 	}
 
-	// TODO: Jupyterhub støtter ikke mergeValues med tom values
-	log.Error("TODO: Jupyterhub støtter ikke mergeValues med tom values")
-	//log.Info("Trigger update of Jupyter")
-	//jupyterValues := chart.JupyterConfigurableValues{
-	//	TeamID: team.ID,
-	//}
-	//if err := c.repo.RegisterUpdateJupyterEvent(ctx, team.ID, jupyterValues); err != nil {
-	//	log.WithError(err).Error("failed while registering Jupyter update event")
-	//	return true
-	//}
+	log.Info("Trigger update of Jupyter")
+	jupyterValues := chart.JupyterConfigurableValues{
+		TeamID: team.ID,
+	}
+	if err := c.repo.RegisterUpdateJupyterEvent(ctx, team.ID, jupyterValues); err != nil {
+		log.WithError(err).Error("failed while registering Jupyter update event")
+		return true
+	}
 
 	log.Info("Trigger update of Airflow")
 	airflowValues := chart.AirflowConfigurableValues{


### PR DESCRIPTION
Denne PRen vil fikse så konfigurerbare jupyter verdier hentes fra databasen når en chart sync trigges av team update eller fra admin panelet.

Brukerne i et team er lagret med eposter i knorten databasen. Vi har derfor behov for å gjøre en sjekk mot AAD for å konvertere epost til ident for brukerne som skal ha tilgang til jupyterhubben. Har derfor endret slik at azure klienten instansieres på utsiden og sendes ned til både event handleren og apiet. Åpen for alternative løsninger på dette, men hadde ikke lyst til å lagre lister med både identer og eposter for brukerne i databasen.