### PR TITLE
add leader election to allow pod replicas

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,8 +16,6 @@ spec:
         app: knorten
     spec:
       serviceAccountName: knorten
-      imagePullSecrets:
-      - name: ghcr-credentials
       containers:
       - name: knorten
         image: europe-west1-docker.pkg.dev/knada-gcp/knada/knorten
@@ -48,6 +46,8 @@ spec:
             value: europe-west1
           - name: GCP_ZONE
             value: europe-west1-b
+          - name: ELECTOR_PATH
+            value: localhost:4040
         envFrom:
         - secretRef:
             name: knorten
@@ -78,6 +78,16 @@ spec:
           runAsUser: 2
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+      - name: elector
+        image: europe-north1-docker.pkg.dev/nais-io/nais/images/elector:20230310-120406-3b3cc7d
+        command:
+        - /elector
+        - --election=knorten
+        - --http=localhost:4040
+        - --election-namespace=knada-system
+        env:
+        - name: ELECTOR_LOG_FORMAT
+          value: json
       volumes:
         - name: helm-repos-config
           configMap:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: knorten
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: knorten

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nais/knorten/pkg/events"
 	"github.com/nais/knorten/pkg/helm"
 	"github.com/nais/knorten/pkg/imageupdater"
-	"github.com/nais/knorten/pkg/leaderelection"
 	"github.com/sirupsen/logrus"
 )
 
@@ -73,19 +72,12 @@ func main() {
 		}
 	}
 
-	isLeader, err := leaderelection.IsLeader()
+	eventHandler, err := events.NewHandler(context.Background(), dbClient, cfg.GCPProject, cfg.GCPRegion, cfg.GCPZone, cfg.AirflowChartVersion, cfg.JupyterChartVersion, cfg.DryRun, cfg.InCluster, log.WithField("subsystem", "events"))
 	if err != nil {
-		log.WithError(err).Fatal("leader election check")
+		log.WithError(err).Fatal("starting event watcher")
+		return
 	}
-
-	if isLeader {
-		eventHandler, err := events.NewHandler(context.Background(), dbClient, cfg.GCPProject, cfg.GCPRegion, cfg.GCPZone, cfg.AirflowChartVersion, cfg.JupyterChartVersion, cfg.DryRun, cfg.InCluster, log.WithField("subsystem", "events"))
-		if err != nil {
-			log.WithError(err).Fatal("starting event watcher")
-			return
-		}
-		eventHandler.Run(10 * time.Second)
-	}
+	eventHandler.Run(10 * time.Second)
 
 	router, err := api.New(dbClient, cfg.DryRun, cfg.ClientID, cfg.ClientSecret, cfg.TenantID, cfg.SessionKey, cfg.AdminGroup, cfg.GCPProject, cfg.GCPZone, log.WithField("subsystem", "api"))
 	if err != nil {

--- a/pkg/events/dispatcher.go
+++ b/pkg/events/dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nais/knorten/pkg/compute"
 	"github.com/nais/knorten/pkg/database"
 	"github.com/nais/knorten/pkg/database/gensql"
+	"github.com/nais/knorten/pkg/leaderelection"
 	"github.com/nais/knorten/pkg/logger"
 	"github.com/nais/knorten/pkg/team"
 	"github.com/sirupsen/logrus"
@@ -144,6 +145,15 @@ func (e EventHandler) Run(tickDuration time.Duration) {
 				e.log.Debug("Event dispatcher run!")
 			case <-e.context.Done():
 				e.log.Debug("Context cancelled, stopping the event dispatcher.")
+				return
+			}
+
+			isLeader, err := leaderelection.IsLeader()
+			if err != nil {
+				e.log.WithError(err).Error("leader election check")
+				return
+			}
+			if !isLeader {
 				return
 			}
 

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -1,0 +1,64 @@
+package leaderelection
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+func IsLeader() (bool, error) {
+	electorPath := os.Getenv("ELECTOR_PATH")
+	if electorPath == "" {
+		// local development
+		return true, nil
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return false, err
+	}
+
+	leader, err := getLeader(electorPath)
+	if err != nil {
+		return false, err
+	}
+
+	return hostname == leader, nil
+}
+
+func getLeader(electorPath string) (string, error) {
+	resp, err := electorRequestWithRetry(electorPath, 3)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var electorResponse struct {
+		Name string
+	}
+
+	if err := json.Unmarshal(bodyBytes, &electorResponse); err != nil {
+		return "", err
+	}
+
+	return electorResponse.Name, nil
+}
+
+func electorRequestWithRetry(electorPath string, numRetries int) (*http.Response, error) {
+	for i := 1; i <= numRetries; i++ {
+		resp, err := http.Get("http://" + electorPath)
+		if err == nil {
+			return resp, nil
+		}
+		time.Sleep(time.Second * time.Duration(i))
+	}
+
+	return nil, fmt.Errorf("no response from elector container after %v retries", numRetries)
+}


### PR DESCRIPTION
Denne PRen vil bruke [nais/elector](https://github.com/nais/elector) til å avgjøre om en pod er leader slik at kun leder-podden håndterer events. Dette tillater oss å ha flere instanser av appen kjørende.