### PR TITLE
Git sync from chart

### DIFF
--- a/pkg/api/admin_test.go
+++ b/pkg/api/admin_test.go
@@ -764,7 +764,11 @@ func prepareAdminTests(ctx context.Context) ([]gensql.Team, error) {
 		return nil, err
 	}
 
-	// global values
+	_, err = db.Exec("DELETE FROM chart_global_values")
+	if err != nil {
+		return nil, err
+	}
+
 	if err := repo.GlobalChartValueInsert(ctx, "jupytervalue", "value", false, gensql.ChartTypeJupyterhub); err != nil {
 		return nil, err
 	}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"database/sql"
 	"html/template"
 	"io"
 	"log"
@@ -22,6 +23,7 @@ import (
 
 var (
 	repo   *database.Repo
+	db     *sql.DB
 	server *httptest.Server
 	user   = auth.User{
 		Name:  "Dum My",
@@ -53,6 +55,10 @@ func TestMain(m *testing.M) {
 	repo, err = database.New(dbConn, "", logrus.NewEntry(logrus.StandardLogger()))
 	if err != nil {
 		log.Fatal(err)
+	}
+	db, err = sql.Open("postgres", dbConn)
+	if err != nil {
+		log.Fatalf("open sql connection: %v", err)
 	}
 
 	azureClient, err := auth.NewAzureClient(true, "", "", "", logger)

--- a/pkg/api/chart.go
+++ b/pkg/api/chart.go
@@ -398,16 +398,6 @@ func (c *client) getEditChart(ctx *gin.Context, teamSlug string, chartType gensq
 		}
 	case gensql.ChartTypeAirflow:
 		airflowValues := chartObjects.(*chart.AirflowConfigurableValues)
-		dagRepo, err := c.repo.TeamValueGet(ctx, chart.TeamValueDagRepo, team.ID)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return nil, err
-		}
-
-		dagRepoBranch, err := c.repo.TeamValueGet(ctx, chart.TeamValueDagRepoBranch, team.ID)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return nil, err
-		}
-
 		restrictEgressTeamValue, err := c.repo.TeamValueGet(ctx, chart.TeamValueKeyRestrictEgress, team.ID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return nil, err
@@ -434,8 +424,8 @@ func (c *client) getEditChart(ctx *gin.Context, teamSlug string, chartType gensq
 		}
 
 		form = airflowForm{
-			DagRepo:        dagRepo.Value,
-			DagRepoBranch:  dagRepoBranch.Value,
+			DagRepo:        airflowValues.DagRepo,
+			DagRepoBranch:  airflowValues.DagRepoBranch,
 			RestrictEgress: restrictEgress,
 			ApiAccess:      apiAccess,
 			AirflowImage:   airflowImage,

--- a/pkg/api/chart.go
+++ b/pkg/api/chart.go
@@ -398,6 +398,16 @@ func (c *client) getEditChart(ctx *gin.Context, teamSlug string, chartType gensq
 		}
 	case gensql.ChartTypeAirflow:
 		airflowValues := chartObjects.(*chart.AirflowConfigurableValues)
+		dagRepo, err := c.repo.TeamValueGet(ctx, chart.TeamValueDagRepo, team.ID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+
+		dagRepoBranch, err := c.repo.TeamValueGet(ctx, chart.TeamValueDagRepoBranch, team.ID)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return nil, err
+		}
+
 		restrictEgressTeamValue, err := c.repo.TeamValueGet(ctx, chart.TeamValueKeyRestrictEgress, team.ID)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return nil, err
@@ -424,8 +434,8 @@ func (c *client) getEditChart(ctx *gin.Context, teamSlug string, chartType gensq
 		}
 
 		form = airflowForm{
-			DagRepo:        airflowValues.DagRepo,
-			DagRepoBranch:  airflowValues.DagRepoBranch,
+			DagRepo:        dagRepo.Value,
+			DagRepoBranch:  dagRepoBranch.Value,
 			RestrictEgress: restrictEgress,
 			ApiAccess:      apiAccess,
 			AirflowImage:   airflowImage,

--- a/pkg/api/chart_test.go
+++ b/pkg/api/chart_test.go
@@ -336,11 +336,13 @@ func TestAirflowAPI(t *testing.T) {
 		}
 	})
 
+	dagRepo := "navikt/repo"
+	branch := "main"
 	expectedRestrictEgress := false
 	expectedValues := chart.AirflowConfigurableValues{
 		TeamID:         team.ID,
-		DagRepo:        "navikt/repo",
-		DagRepoBranch:  "main",
+		DagRepo:        dagRepo,
+		DagRepoBranch:  branch,
 		RestrictEgress: expectedRestrictEgress,
 	}
 
@@ -348,6 +350,12 @@ func TestAirflowAPI(t *testing.T) {
 		t.Error(err)
 	}
 	if err := repo.TeamChartValueInsert(ctx, chart.TeamValueKeyRestrictEgress, strconv.FormatBool(expectedRestrictEgress), team.ID, gensql.ChartTypeAirflow); err != nil {
+		t.Error(err)
+	}
+	if err := repo.TeamChartValueInsert(ctx, chart.TeamValueDagRepo, dagRepo, team.ID, gensql.ChartTypeAirflow); err != nil {
+		t.Error(err)
+	}
+	if err := repo.TeamChartValueInsert(ctx, chart.TeamValueDagRepoBranch, branch, team.ID, gensql.ChartTypeAirflow); err != nil {
 		t.Error(err)
 	}
 

--- a/pkg/api/chart_test.go
+++ b/pkg/api/chart_test.go
@@ -352,12 +352,6 @@ func TestAirflowAPI(t *testing.T) {
 	if err := repo.TeamChartValueInsert(ctx, chart.TeamValueKeyRestrictEgress, strconv.FormatBool(expectedRestrictEgress), team.ID, gensql.ChartTypeAirflow); err != nil {
 		t.Error(err)
 	}
-	if err := repo.TeamChartValueInsert(ctx, chart.TeamValueDagRepo, dagRepo, team.ID, gensql.ChartTypeAirflow); err != nil {
-		t.Error(err)
-	}
-	if err := repo.TeamChartValueInsert(ctx, chart.TeamValueDagRepoBranch, branch, team.ID, gensql.ChartTypeAirflow); err != nil {
-		t.Error(err)
-	}
 
 	t.Run("get edit airflow html", func(t *testing.T) {
 		resp, err := server.Client().Get(fmt.Sprintf("%v/team/%v/airflow/edit", server.URL, team.Slug))

--- a/pkg/chart/airflow.go
+++ b/pkg/chart/airflow.go
@@ -88,27 +88,37 @@ func (c Client) syncAirflow(ctx context.Context, configurableValues AirflowConfi
 	}
 
 	if err := c.repo.TeamValueInsert(ctx, gensql.ChartTypeAirflow, teamValueKeyDatabasePassword, values.PostgresPassword, team.ID); err != nil {
-		log.WithError(err).Error("inserting postgres team value to database")
+		log.WithError(err).Errorf("inserting %v team value to database", teamValueKeyDatabasePassword)
 		return err
 	}
 
 	if err := c.repo.TeamValueInsert(ctx, gensql.ChartTypeAirflow, teamValueKeyFernetKey, values.FernetKey, team.ID); err != nil {
-		log.WithError(err).Error("inserting fernet key team value to database")
+		log.WithError(err).Errorf("inserting %v team value to database", teamValueKeyFernetKey)
 		return err
 	}
 
 	if err := c.repo.TeamValueInsert(ctx, gensql.ChartTypeAirflow, teamValueKeyWebserverSecret, values.WebserverSecretKey, team.ID); err != nil {
-		log.WithError(err).Error("inserting webserver team value to database")
+		log.WithError(err).Errorf("inserting %v team value to database", teamValueKeyWebserverSecret)
 		return err
 	}
 
 	if err := c.repo.TeamValueInsert(ctx, gensql.ChartTypeAirflow, TeamValueKeyRestrictEgress, strconv.FormatBool(values.RestrictEgress), team.ID); err != nil {
-		log.WithError(err).Error("inserting restrict egress team value to database")
+		log.WithError(err).Errorf("inserting %v team value to database", TeamValueKeyRestrictEgress)
 		return err
 	}
 
 	if err := c.repo.TeamValueInsert(ctx, gensql.ChartTypeAirflow, TeamValueKeyApiAccess, strconv.FormatBool(values.ApiAccess), team.ID); err != nil {
-		log.WithError(err).Error("inserting api access team value to database")
+		log.WithError(err).Errorf("inserting %v team value to database", TeamValueKeyApiAccess)
+		return err
+	}
+
+	if err := c.repo.TeamValueInsert(ctx, gensql.ChartTypeAirflow, TeamValueDagRepo, values.DagRepo, team.ID); err != nil {
+		log.WithError(err).Errorf("inserting %v team value to database", TeamValueDagRepo)
+		return err
+	}
+
+	if err := c.repo.TeamValueInsert(ctx, gensql.ChartTypeAirflow, TeamValueDagRepoBranch, values.DagRepoBranch, team.ID); err != nil {
+		log.WithError(err).Errorf("inserting %v team value to database", TeamValueDagRepoBranch)
 		return err
 	}
 

--- a/pkg/chart/airflow.go
+++ b/pkg/chart/airflow.go
@@ -54,21 +54,12 @@ type AirflowValues struct {
 	WebserverSecretKey string // Knorten sets Helm value pointing to k8s secret
 
 	// Generated Helm config
-
-	ExtraEnvs    string `helm:"env"`
-	IngressHosts string `helm:"ingress.web.hosts"`
-	// SchedulerGitInitRepo       string `helm:"scheduler.extraInitContainers.[0].args.[0]"`
-	// SchedulerGitInitRepoBranch string `helm:"scheduler.extraInitContainers.[0].args.[1]"`
-	// SchedulerGitSynkRepo       string `helm:"scheduler.extraContainers.[0].args.[0]"`
-	// SchedulerGitSynkRepoBranch string `helm:"scheduler.extraContainers.[0].args.[1]"`
-	WebserverEnv string `helm:"webserver.env"`
-	GitSyncEnv   string `helm:"dags.gitSync.env"`
-	// WebserverGitSynkRepo       string `helm:"webserver.extraContainers.[0].args.[0]"`
-	// WebserverGitSynkRepoBranch string `helm:"webserver.extraContainers.[0].args.[1]"`
+	ExtraEnvs               string `helm:"env"`
+	IngressHosts            string `helm:"ingress.web.hosts"`
+	WebserverEnv            string `helm:"webserver.env"`
+	GitSyncEnv              string `helm:"dags.gitSync.env"`
 	WebserverServiceAccount string `helm:"webserver.serviceAccount.name"`
 	WorkerServiceAccount    string `helm:"workers.serviceAccount.name"`
-	// WorkersGitSynkRepo         string `helm:"workers.extraInitContainers.[0].args.[0]"`
-	// WorkersGitSynkRepoBranch   string `helm:"workers.extraInitContainers.[0].args.[1]"`
 }
 
 func (c Client) syncAirflow(ctx context.Context, configurableValues AirflowConfigurableValues, log logger.Logger) error {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -186,19 +186,12 @@ func TestCharts(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"webserver.env":                              `[{"name":"AIRFLOW_USERS","value":"dummy@nav.no,user.one@nav.no"}]`,
-				"webserver.extraContainers.[0].args.[0]":     "navikt/my-dags",
-				"webserver.extraContainers.[0].args.[1]":     "main",
-				"scheduler.extraInitContainers.[0].args.[0]": "navikt/my-dags",
-				"scheduler.extraInitContainers.[0].args.[1]": "main",
-				"scheduler.extraContainers.[0].args.[0]":     "navikt/my-dags",
-				"scheduler.extraContainers.[0].args.[1]":     "main",
-				"workers.extraInitContainers.[0].args.[0]":   "navikt/my-dags",
-				"workers.extraInitContainers.[0].args.[1]":   "main",
-				"webserver.serviceAccount.name":              "test-team-1234",
-				"workers.serviceAccount.name":                "test-team-1234",
-				"env":                                        `[{"name":"KNADA_TEAM_SECRET","value":"projects/project/secrets/test-team-1234"},{"name":"TEAM","value":"test-team-1234"},{"name":"NAMESPACE","value":"team-test-team-1234"},{"name":"AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER","value":"gs://airflow-logs-test-team-1234-north"},{"name":"AIRFLOW__LOGGING__REMOTE_LOGGING","value":"True"}]`,
-				"ingress.web.hosts":                          `[{"name":"test-team.airflow.knada.io","tls":{"enabled":true,"secretName":"airflow-certificate"}}]`,
+				"webserver.env":                 `[{"name":"AIRFLOW_USERS","value":"dummy@nav.no,user.one@nav.no"}]`,
+				"dags.gitSync.env":              `[{"name":"DAG_REPO","value":"navikt/my-dags"},{"name":"DAG_REPO_BRANCH","value":"main"},{"name":"DAG_REPO_DIR","value":"/dags"},{"name":"SYNC_TIME","value":"60"}]`,
+				"webserver.serviceAccount.name": "test-team-1234",
+				"workers.serviceAccount.name":   "test-team-1234",
+				"env":                           `[{"name":"KNADA_TEAM_SECRET","value":"projects/project/secrets/test-team-1234"},{"name":"TEAM","value":"test-team-1234"},{"name":"NAMESPACE","value":"team-test-team-1234"},{"name":"AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER","value":"gs://airflow-logs-test-team-1234-north"},{"name":"AIRFLOW__LOGGING__REMOTE_LOGGING","value":"True"}]`,
+				"ingress.web.hosts":             `[{"name":"test-team.airflow.knada.io","tls":{"enabled":true,"secretName":"airflow-certificate"}}]`,
 			},
 		},
 		{
@@ -213,19 +206,12 @@ func TestCharts(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"workers.serviceAccount.name":                "test-team-1234",
-				"webserver.serviceAccount.name":              "test-team-1234",
-				"env":                                        `[{"name":"KNADA_TEAM_SECRET","value":"projects/project/secrets/test-team-1234"},{"name":"TEAM","value":"test-team-1234"},{"name":"NAMESPACE","value":"team-test-team-1234"},{"name":"AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER","value":"gs://airflow-logs-test-team-1234-north"},{"name":"AIRFLOW__LOGGING__REMOTE_LOGGING","value":"True"}]`,
-				"webserver.env":                              `[{"name":"AIRFLOW_USERS","value":"dummy@nav.no,user.one@nav.no"}]`,
-				"ingress.web.hosts":                          `[{"name":"test-team.airflow.knada.io","tls":{"enabled":true,"secretName":"airflow-certificate"}}]`,
-				"webserver.extraContainers.[0].args.[0]":     "navikt/other-dags",
-				"webserver.extraContainers.[0].args.[1]":     "master",
-				"scheduler.extraInitContainers.[0].args.[0]": "navikt/other-dags",
-				"scheduler.extraInitContainers.[0].args.[1]": "master",
-				"scheduler.extraContainers.[0].args.[0]":     "navikt/other-dags",
-				"scheduler.extraContainers.[0].args.[1]":     "master",
-				"workers.extraInitContainers.[0].args.[0]":   "navikt/other-dags",
-				"workers.extraInitContainers.[0].args.[1]":   "master",
+				"workers.serviceAccount.name":   "test-team-1234",
+				"webserver.serviceAccount.name": "test-team-1234",
+				"env":                           `[{"name":"KNADA_TEAM_SECRET","value":"projects/project/secrets/test-team-1234"},{"name":"TEAM","value":"test-team-1234"},{"name":"NAMESPACE","value":"team-test-team-1234"},{"name":"AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER","value":"gs://airflow-logs-test-team-1234-north"},{"name":"AIRFLOW__LOGGING__REMOTE_LOGGING","value":"True"}]`,
+				"webserver.env":                 `[{"name":"AIRFLOW_USERS","value":"dummy@nav.no,user.one@nav.no"}]`,
+				"ingress.web.hosts":             `[{"name":"test-team.airflow.knada.io","tls":{"enabled":true,"secretName":"airflow-certificate"}}]`,
+				"dags.gitSync.env":              `[{"name":"DAG_REPO","value":"navikt/other-dags"},{"name":"DAG_REPO_BRANCH","value":"master"},{"name":"DAG_REPO_DIR","value":"/dags"},{"name":"SYNC_TIME","value":"60"}]`,
 			},
 		},
 		{
@@ -282,20 +268,6 @@ func prepareChartTests(ctx context.Context) (gensql.Team, error) {
 
 	if err := helm.UpdateHelmRepositories(); err != nil {
 		return gensql.Team{}, err
-	}
-
-	// global values for airflow
-	globalValues := map[string]string{
-		"webserver.extraContainers":     `[{"name": "git-nada", "image": "registry.k8s.io/git-sync/git-sync:v3.6.3","args": ["", "", "/dags", "60"], "volumeMounts":[{"mountPath":"/dags","name":"dags"}]}]`,
-		"scheduler.extraContainers":     `[{"name": "git-nada", "image": "registry.k8s.io/git-sync/git-sync:v3.6.3","args": ["", "", "/dags", "60"], "volumeMounts":[{"mountPath":"/dags","name":"dags"}]}]`,
-		"scheduler.extraInitContainers": `[{"name": "git-nada-clone", "image": "registry.k8s.io/git-sync/git-sync:v3.6.3","args": ["", "", "/dags", "60"], "volumeMounts":[{"mountPath":"/dags","name":"dags"}]}]`,
-		"workers.extraInitContainers":   `[{"name": "git-nada", "image": "registry.k8s.io/git-sync/git-sync:v3.6.3","args": ["", "", "/dags", "60"], "volumeMounts":[{"mountPath":"/dags","name":"dags"}]}]`,
-	}
-
-	for k, v := range globalValues {
-		if err := repo.GlobalChartValueInsert(ctx, k, v, false, gensql.ChartTypeAirflow); err != nil {
-			return gensql.Team{}, err
-		}
 	}
 
 	return team, repo.TeamCreate(ctx, team)

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -187,7 +187,8 @@ func TestCharts(t *testing.T) {
 			},
 			want: map[string]string{
 				"webserver.env":                 `[{"name":"AIRFLOW_USERS","value":"dummy@nav.no,user.one@nav.no"}]`,
-				"dags.gitSync.env":              `[{"name":"DAG_REPO","value":"navikt/my-dags"},{"name":"DAG_REPO_BRANCH","value":"main"},{"name":"DAG_REPO_DIR","value":"/dags"},{"name":"SYNC_TIME","value":"60"}]`,
+				"dags.gitSync.repo":             "navikt/my-dags",
+				"dags.gitSync.branch":           "main",
 				"webserver.serviceAccount.name": "test-team-1234",
 				"workers.serviceAccount.name":   "test-team-1234",
 				"env":                           `[{"name":"KNADA_TEAM_SECRET","value":"projects/project/secrets/test-team-1234"},{"name":"TEAM","value":"test-team-1234"},{"name":"NAMESPACE","value":"team-test-team-1234"},{"name":"AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER","value":"gs://airflow-logs-test-team-1234-north"},{"name":"AIRFLOW__LOGGING__REMOTE_LOGGING","value":"True"}]`,
@@ -211,7 +212,8 @@ func TestCharts(t *testing.T) {
 				"env":                           `[{"name":"KNADA_TEAM_SECRET","value":"projects/project/secrets/test-team-1234"},{"name":"TEAM","value":"test-team-1234"},{"name":"NAMESPACE","value":"team-test-team-1234"},{"name":"AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER","value":"gs://airflow-logs-test-team-1234-north"},{"name":"AIRFLOW__LOGGING__REMOTE_LOGGING","value":"True"}]`,
 				"webserver.env":                 `[{"name":"AIRFLOW_USERS","value":"dummy@nav.no,user.one@nav.no"}]`,
 				"ingress.web.hosts":             `[{"name":"test-team.airflow.knada.io","tls":{"enabled":true,"secretName":"airflow-certificate"}}]`,
-				"dags.gitSync.env":              `[{"name":"DAG_REPO","value":"navikt/other-dags"},{"name":"DAG_REPO_BRANCH","value":"master"},{"name":"DAG_REPO_DIR","value":"/dags"},{"name":"SYNC_TIME","value":"60"}]`,
+				"dags.gitSync.repo":             "navikt/other-dags",
+				"dags.gitSync.branch":           "master",
 			},
 		},
 		{

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -8,16 +8,15 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('dags.gitSync.uid','50000','airflow'),
     ('dags.gitSync.wait','30','airflow'),
     ('images.gitSync.repository','europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync','airflow'),
-    ('images.gitSync.tag','2023-09-19-7ef78c9','airflow');
-
-UPDATE chart_global_values SET "value" = '/opt/airflow/dags' WHERE "key" = 'config.core.dags_folder' AND "chart_type" = 'airflow';
+    ('images.gitSync.tag','2023-09-20-3eab00d','airflow');
 
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
     ('webserver.extraVolumes','[{"name":"airflow-auth","configMap":{"name":"airflow-auth-cm"}},{"name":"airflow-webserver","configMap":{"name":"airflow-webserver-cm"}}]','airflow'),
     ('webserver.extraVolumeMounts','[{"mountPath":"/opt/airflow/auth.py","subPath":"auth.py","name":"airflow-auth"},{"mountPath":"/opt/airflow/webserver_config.py","subPath":"webserver_config.py","name":"airflow-webserver"}]','airflow'),
     ('scheduler.extraVolumes','[{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}}]','airflow'),
+    ('scheduler.extraVolumeMounts','[{"mountPath":"/dags","name":"dags"}]','airflow'),
     ('workers.extraVolumes','[{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}},{"name":"ca-bundle-pem","configMap":{"defaultMode":420,"name":"ca-bundle-pem"}}]','airflow'),
-    ('workers.extraVolumeMounts','[{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]','airflow');
+    ('workers.extraVolumeMounts','[{"mountPath":"/dags","name":"dags"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]','airflow');
 
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
     ('workers.extraInitContainers','[{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');
@@ -75,7 +74,5 @@ INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
     (SELECT 'workers.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.branch');
-
-UPDATE chart_global_values SET "value" = '/dags' WHERE "key" = 'config.core.dags_folder' AND "chart_type" = 'airflow';
 
 DELETE FROM chart_team_values WHERE "key" IN ('dags.gitSync.repo','dags.gitSync.branch','dags.gitSync.extraVolumeMounts','images.gitSync.repository','images.gitSync.tag');

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -22,7 +22,7 @@ WITH processing AS (
 )
 
 INSERT INTO chart_team_values (key,value,team_id,chart_type)
-(SELECT 'dags.gitSync.env', CONCAT('[{"name":"DAG_REPO","value":"',vals[2],'"},{"name":"DAG_REPO_BRANCH","value":"', vals[1],'"},{"name":"DAG_REPO_DIR","value":"/dags"},{"name":"SYNC_TIME","value":"60"}]'), team_id, 'airflow' FROM outers);
+(SELECT 'dags.gitSync.env', CONCAT('[{"name":"DAG_REPO","value":"',vals[1],'"},{"name":"DAG_REPO_BRANCH","value":"', vals[2],'"},{"name":"DAG_REPO_DIR","value":"/dags"},{"name":"SYNC_TIME","value":"60"}]'), team_id, 'airflow' FROM outers);
 
 DELETE FROM chart_team_values WHERE "key" IN (
     'scheduler.extraInitContainers.[0].args.[0]',

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -6,8 +6,11 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('dags.gitSync.enabled','true','airflow'),
     ('dags.gitSync.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]','airflow'),
     ('dags.gitSync.uid','50000','airflow'),
+    ('dags.gitSync.wait','30','airflow'),
     ('images.gitSync.repository','europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync','airflow'),
     ('images.gitSync.tag','2023-09-18-2c62c53','airflow');
+
+UPDATE chart_global_values SET "value" = '/opt/airflow/dags' WHERE "key" = 'config.core.dags_folder' AND "chart_type" = 'airflow';
 
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
     ('webserver.extraVolumes','[{"name":"airflow-auth","configMap":{"name":"airflow-auth-cm"}},{"name":"airflow-webserver","configMap":{"name":"airflow-webserver-cm"}}]','airflow'),
@@ -16,18 +19,8 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
     ('workers.extraInitContainers','[{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');
 
-UPDATE chart_team_values SET "key" = 'dagRepo,omit' WHERE "key" = 'scheduler.extraContainers.[0].args.[0]';
-UPDATE chart_team_values SET "key" = 'dagRepoBranch,omit' WHERE "key" = 'scheduler.extraContainers.[0].args.[1]';
-
-WITH processing AS (
-  SELECT DISTINCT ON (team_id,key) team_id, key, value, created FROM
-  (SELECT team_id, key, value, created FROM chart_team_values WHERE key = 'workers.extraInitContainers.[0].args.[0]' OR key = 'workers.extraInitContainers.[0].args.[1]' ORDER BY created DESC) as target
-), outers AS (
-  SELECT team_id, ARRAY_AGG(key), ARRAY_AGG(value) as vals FROM processing GROUP BY team_id
-)
-
-INSERT INTO chart_team_values (key,value,team_id,chart_type)
-(SELECT 'dags.gitSync.env', CONCAT('[{"name":"DAG_REPO","value":"',vals[1],'"},{"name":"DAG_REPO_BRANCH","value":"', vals[2],'"},{"name":"DAG_REPO_DIR","value":"/dags"},{"name":"SYNC_TIME","value":"60"}]'), team_id, 'airflow' FROM outers);
+UPDATE chart_team_values SET "key" = 'dags.gitSync.repo' WHERE "key" = 'scheduler.extraContainers.[0].args.[0]';
+UPDATE chart_team_values SET "key" = 'dags.gitSync.branch' WHERE "key" = 'scheduler.extraContainers.[0].args.[1]';
 
 DELETE FROM chart_team_values WHERE "key" IN (
     'scheduler.extraInitContainers.[0].args.[0]',
@@ -53,27 +46,29 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('webserver.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/opt/airflow/auth.py","subPath":"auth.py","name":"airflow-auth"},{"mountPath":"/opt/airflow/webserver_config.py","subPath":"webserver_config.py","name":"airflow-webserver"}]','airflow');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'scheduler.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+    (SELECT 'scheduler.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.repo');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'scheduler.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+    (SELECT 'scheduler.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.branch');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'scheduler.extraContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+    (SELECT 'scheduler.extraContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.repo');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'scheduler.extraContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+    (SELECT 'scheduler.extraContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.branch');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'webserver.extraContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+    (SELECT 'webserver.extraContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.repo');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'webserver.extraContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+    (SELECT 'webserver.extraContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.branch');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'workers.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+    (SELECT 'workers.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.repo');
 
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
-    (SELECT 'workers.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+    (SELECT 'workers.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dags.gitSync.branch');
 
-DELETE FROM chart_team_values WHERE "key" IN ('dagRepo,omit','dagRepoBranch,omit','dags.gitSync.env','dags.gitSync.extraVolumeMounts','images.gitSync.repository','images.gitSync.tag');
+UPDATE chart_global_values SET "value" = '/dags' WHERE "key" = 'config.core.dags_folder' AND "chart_type" = 'airflow';
+
+DELETE FROM chart_team_values WHERE "key" IN ('dags.gitSync.repo','dags.gitSync.branch','dags.gitSync.extraVolumeMounts','images.gitSync.repository','images.gitSync.tag');

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -21,7 +21,7 @@ DELETE FROM chart_team_values WHERE "key" IN (
     'workers.extraInitContainers.[0].args.[1]',
     'webserver.extraContainers.[0].args.[0]',
     'webserver.extraContainers.[0].args.[1]'
-)
+);
 
 -- +goose Down
 DELETE FROM chart_global_values WHERE "key" = 'workers.extraInitContainers';
@@ -41,12 +41,28 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('webserver.extraVolumes','[{"name":"airflow-auth","configMap":{"name":"airflow-auth-cm"}},{"name":"airflow-webserver","configMap":{"name":"airflow-webserver-cm"}},{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}}]','airflow'),
     ('webserver.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/opt/airflow/auth.py","subPath":"auth.py","name":"airflow-auth"},{"mountPath":"/opt/airflow/webserver_config.py","subPath":"webserver_config.py","name":"airflow-webserver"}]','airflow');
 
-INSERT INTO chart_team_values ('key','value','chart_type','team_id')
-    (SELECT 'scheduler.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
-    (SELECT 'scheduler.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit'),
-    (SELECT 'scheduler.extraContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
-    (SELECT 'scheduler.extraContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit'),
-    (SELECT 'webserver.extraContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
-    (SELECT 'webserver.extraContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit'),
-    (SELECT 'workers.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
-    (SELECT 'workers.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'scheduler.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'scheduler.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'scheduler.extraContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'scheduler.extraContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'webserver.extraContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'webserver.extraContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'workers.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepo,omit');
+
+INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
+    (SELECT 'workers.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
+
+DELETE FROM chart_team_values WHERE "key" IN ('dagRepo,omit','dagRepoBranch,omit');

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+DELETE FROM chart_global_values WHERE "key" IN ('scheduler.extraContainers','scheduler.extraInitContainers','webserver.extraContainers','workers.extraInitContainers');
+DELETE FROM chart_global_values WHERE "key" IN ('scheduler.extraVolumes','scheduler.extraVolumeMounts','workers.extraVolumes','workers.extraVolumeMounts','webserver.extraVolumes','webserver.extraVolumeMounts');
+
+INSERT INTO chart_global_values ("key","value","chart_type") VALUES
+    ('dags.gitSync.enabled','true','airflow'),
+    ('dags.gitSync.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]','airflow'),
+    ('images.gitSync.repository','europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync','airflow'),
+    ('images.gitSync.tag','2023-09-18-2c62c53','airflow');
+
+INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
+    ('workers.extraInitContainers','[{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');
+
+INSERT INTO chart_team_values
+
+-- +goose Down
+DELETE FROM chart_global_values WHERE "key" = 'workers.extraInitContainers';
+DELETE FROM chart_global_values WHERE "key" IN ('dags.gitSync.enabled','dags.gitSync.extraVolumeMounts','images.gitSync.repository','images.gitSync.tag');
+
+INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
+    ('scheduler.extraContainers','[{"name":"git-sync","image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync:2023-08-31-2f998de","resources":{"requests":{"cpu":"100m","memory":"128Mi","ephemeral-storage":"64Mi"}},"command":["/bin/sh","/git-sync.sh"],"args":["","","/dags","60"],"volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]}]','airflow'),
+    ('scheduler.extraInitContainers','[{"name":"git-clone","image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync:2023-08-31-2f998de","resources":{"requests":{"cpu":"100m","memory":"128Mi","ephemeral-storage":"64Mi"}},"command":["/bin/sh","/git-clone.sh"],"args":["","","/dags","60"],"volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]}]','airflow'),
+    ('webserver.extraContainers','[{"name":"git-sync","image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync:2023-08-31-2f998de","resources":{"requests":{"cpu":"100m","memory":"128Mi","ephemeral-storage":"64Mi"}},"command":["/bin/sh","/git-sync.sh"],"args":["","","/dags","60"],"volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]}]','airflow'),
+    ('workers.extraInitContainers','[{"name":"git-clone","image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync:2023-08-31-2f998de","command":["/bin/sh","/git-clone.sh"],"args":["","","/dags","60"],"volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]},{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');
+
+INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
+    ('scheduler.extraVolumes','[{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}}]','airflow'),
+    ('scheduler.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]','airflow'),
+    ('workers.extraVolumes','[{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}},{"name":"ca-bundle-pem","configMap":{"defaultMode":420,"name":"ca-bundle-pem"}}]','airflow'),
+    ('workers.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]','airflow'),
+    ('webserver.extraVolumes','[{"name":"airflow-auth","configMap":{"name":"airflow-auth-cm"}},{"name":"airflow-webserver","configMap":{"name":"airflow-webserver-cm"}},{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}}]','airflow'),
+    ('webserver.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/opt/airflow/auth.py","subPath":"auth.py","name":"airflow-auth"},{"mountPath":"/opt/airflow/webserver_config.py","subPath":"webserver_config.py","name":"airflow-webserver"}]','airflow');

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -11,7 +11,17 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
     ('workers.extraInitContainers','[{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');
 
-INSERT INTO chart_team_values
+UPDATE chart_team_values SET "key" = 'dagRepo,omit' WHERE "key" = 'scheduler.extraContainers.[0].args.[0]';
+UPDATE chart_team_values SET "key" = 'dagRepoBranch,omit' WHERE "key" = 'scheduler.extraContainers.[0].args.[1]';
+
+DELETE FROM chart_team_values WHERE "key" IN (
+    'scheduler.extraInitContainers.[0].args.[0]',
+    'scheduler.extraInitContainers.[0].args.[1]',
+    'workers.extraInitContainers.[0].args.[0]',
+    'workers.extraInitContainers.[0].args.[1]',
+    'webserver.extraContainers.[0].args.[0]',
+    'webserver.extraContainers.[0].args.[1]'
+)
 
 -- +goose Down
 DELETE FROM chart_global_values WHERE "key" = 'workers.extraInitContainers';
@@ -30,3 +40,13 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('workers.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]','airflow'),
     ('webserver.extraVolumes','[{"name":"airflow-auth","configMap":{"name":"airflow-auth-cm"}},{"name":"airflow-webserver","configMap":{"name":"airflow-webserver-cm"}},{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}}]','airflow'),
     ('webserver.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/opt/airflow/auth.py","subPath":"auth.py","name":"airflow-auth"},{"mountPath":"/opt/airflow/webserver_config.py","subPath":"webserver_config.py","name":"airflow-webserver"}]','airflow');
+
+INSERT INTO chart_team_values ('key','value','chart_type','team_id')
+    (SELECT 'scheduler.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
+    (SELECT 'scheduler.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit'),
+    (SELECT 'scheduler.extraContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
+    (SELECT 'scheduler.extraContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit'),
+    (SELECT 'webserver.extraContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
+    (SELECT 'webserver.extraContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit'),
+    (SELECT 'workers.extraInitContainers.[0].args.[0]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepo,omit'),
+    (SELECT 'workers.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -5,6 +5,7 @@ DELETE FROM chart_global_values WHERE "key" IN ('webserver.extraVolumes','webser
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('dags.gitSync.enabled','true','airflow'),
     ('dags.gitSync.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]','airflow'),
+    ('dags.gitSync.uid','50000','airflow'),
     ('images.gitSync.repository','europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync','airflow'),
     ('images.gitSync.tag','2023-09-18-2c62c53','airflow');
 

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -1,12 +1,16 @@
 -- +goose Up
 DELETE FROM chart_global_values WHERE "key" IN ('scheduler.extraContainers','scheduler.extraInitContainers','webserver.extraContainers','workers.extraInitContainers');
-DELETE FROM chart_global_values WHERE "key" IN ('scheduler.extraVolumes','scheduler.extraVolumeMounts','workers.extraVolumes','workers.extraVolumeMounts','webserver.extraVolumes','webserver.extraVolumeMounts');
+DELETE FROM chart_global_values WHERE "key" IN ('webserver.extraVolumes','webserver.extraVolumeMounts');
 
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('dags.gitSync.enabled','true','airflow'),
     ('dags.gitSync.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]','airflow'),
     ('images.gitSync.repository','europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync','airflow'),
     ('images.gitSync.tag','2023-09-18-2c62c53','airflow');
+
+INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
+    ('webserver.extraVolumes','[{"name":"airflow-auth","configMap":{"name":"airflow-auth-cm"}},{"name":"airflow-webserver","configMap":{"name":"airflow-webserver-cm"}}]','airflow'),
+    ('webserver.extraVolumeMounts','[{"mountPath":"/opt/airflow/auth.py","subPath":"auth.py","name":"airflow-auth"},{"mountPath":"/opt/airflow/webserver_config.py","subPath":"webserver_config.py","name":"airflow-webserver"}]','airflow');
 
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
     ('workers.extraInitContainers','[{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');
@@ -44,10 +48,6 @@ INSERT INTO chart_global_values ("key","value","chart_type") VALUES
     ('workers.extraInitContainers','[{"name":"git-clone","image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/git-sync:2023-08-31-2f998de","command":["/bin/sh","/git-clone.sh"],"args":["","","/dags","60"],"volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]},{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');
 
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
-    ('scheduler.extraVolumes','[{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}}]','airflow'),
-    ('scheduler.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"}]','airflow'),
-    ('workers.extraVolumes','[{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}},{"name":"ca-bundle-pem","configMap":{"defaultMode":420,"name":"ca-bundle-pem"}}]','airflow'),
-    ('workers.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]','airflow'),
     ('webserver.extraVolumes','[{"name":"airflow-auth","configMap":{"name":"airflow-auth-cm"}},{"name":"airflow-webserver","configMap":{"name":"airflow-webserver-cm"}},{"name":"dags-data","emptyDir":{}},{"name":"github-app-secret","secret":{"defaultMode":448,"secretName":"github-secret"}}]','airflow'),
     ('webserver.extraVolumeMounts','[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/keys","name":"github-app-secret"},{"mountPath":"/opt/airflow/auth.py","subPath":"auth.py","name":"airflow-auth"},{"mountPath":"/opt/airflow/webserver_config.py","subPath":"webserver_config.py","name":"airflow-webserver"}]','airflow');
 

--- a/pkg/database/migrations/026_use_git_sync_from_chart.sql
+++ b/pkg/database/migrations/026_use_git_sync_from_chart.sql
@@ -65,4 +65,4 @@ INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
 INSERT INTO chart_team_values ("key","value","chart_type","team_id","created")
     (SELECT 'workers.extraInitContainers.[0].args.[1]', "value", "chart_type", "team_id", "created" FROM chart_team_values WHERE "key" = 'dagRepoBranch,omit');
 
-DELETE FROM chart_team_values WHERE "key" IN ('dagRepo,omit','dagRepoBranch,omit');
+DELETE FROM chart_team_values WHERE "key" IN ('dagRepo,omit','dagRepoBranch,omit','dags.gitSync.env','dags.gitSync.extraVolumeMounts','images.gitSync.repository','images.gitSync.tag');

--- a/pkg/database/migrations/027_remove_knaudit_container_spec.sql
+++ b/pkg/database/migrations/027_remove_knaudit_container_spec.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+DELETE FROM chart_global_values WHERE "key" = 'workers.extraInitContainers';
+
+INSERT INTO chart_global_values ("key","value","chart_type") 
+    VALUES ('knauditImage,omit','europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c','airflow');
+
+-- +goose Down
+DELETE FROM chart_global_values WHERE "key" = 'knauditImage,omit'
+
+INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
+    ('workers.extraInitContainers','[{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');

--- a/pkg/database/migrations/027_remove_knaudit_container_spec.sql
+++ b/pkg/database/migrations/027_remove_knaudit_container_spec.sql
@@ -5,7 +5,7 @@ INSERT INTO chart_global_values ("key","value","chart_type")
     VALUES ('knauditImage,omit','europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c','airflow');
 
 -- +goose Down
-DELETE FROM chart_global_values WHERE "key" = 'knauditImage,omit'
+DELETE FROM chart_global_values WHERE "key" = 'knauditImage,omit';
 
 INSERT INTO chart_global_values ("key","value","chart_type") VALUES 
     ('workers.extraInitContainers','[{"name":"knaudit","env":[{"name":"NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}},{"name":"ORACLE_URL","valueFrom":{"secretKeyRef":{"name":"oracle-url","key":"ORACLE_URL"}}},{"name":"CA_CERT_PATH","value":"/etc/pki/tls/certs/ca-bundle.crt"},{"name":"GIT_REPO_PATH","value":"/dags"},{"name":"AIRFLOW_DAG_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''dag_id'']"}}},{"name":"AIRFLOW_RUN_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''run_id'']"}}},{"name":"AIRFLOW_TASK_ID","valueFrom":{"fieldRef":{"fieldPath":"metadata.annotations[''task_id'']"}}},{"name":"AIRFLOW_DB_URL","valueFrom":{"secretKeyRef":{"name":"airflow-db","key":"connection"}}}],"image":"europe-north1-docker.pkg.dev/knada-gcp/knada-north/knaudit:2023-09-04-34a8e3c","volumeMounts":[{"mountPath":"/dags","name":"dags-data"},{"mountPath":"/etc/pki/tls/certs/ca-bundle.crt","name":"ca-bundle-pem","readOnly":true,"subPath":"ca-bundle.pem"}]}]','airflow');

--- a/pkg/helm/airflow.go
+++ b/pkg/helm/airflow.go
@@ -14,7 +14,7 @@ func (c Client) createKnauditInitContainer(ctx context.Context) (map[string]any,
 
 	return map[string]any{
 		"workers": map[string]any{
-			"extraContainers": []map[string]any{
+			"extraInitContainers": []map[string]any{
 				{
 					"name":  "knaudit",
 					"image": knauditImage.Value,

--- a/pkg/helm/airflow.go
+++ b/pkg/helm/airflow.go
@@ -1,0 +1,77 @@
+package helm
+
+import (
+	"context"
+
+	"github.com/nais/knorten/pkg/database/gensql"
+)
+
+func (c Client) createKnauditInitContainer(ctx context.Context) (map[string]any, error) {
+	knauditImage, err := c.repo.GlobalValueGet(ctx, gensql.ChartTypeAirflow, "knauditImage,omit")
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"workers": map[string]any{
+			"extraContainers": []map[string]any{
+				{
+					"name":  "knaudit",
+					"image": knauditImage.Value,
+					"env": []map[string]any{
+						{
+							"name":      "NAMESPACE",
+							"valueFrom": map[string]any{"fieldRef": map[string]string{"fieldPath": "metadata.namespace"}},
+						},
+						{
+							"name":      "ORACLE_URL",
+							"valueFrom": map[string]any{"secretKeyRef": map[string]string{"name": "oracle-url", "key": "ORACLE_URL"}},
+						},
+						{
+							"name":  "CA_CERT_PATH",
+							"value": "/etc/pki/tls/certs/ca-bundle.crt",
+						},
+						{
+							"name":  "GIT_REPO_PATH",
+							"value": "/dags",
+						},
+						{
+							"name":      "AIRFLOW_DAG_ID",
+							"valueFrom": map[string]any{"fieldRef": map[string]string{"fieldPath": "metadata.annotations['dag_id']"}},
+						},
+						{
+							"name":      "AIRFLOW_RUN_ID",
+							"valueFrom": map[string]any{"fieldRef": map[string]string{"fieldPath": "metadata.annotations['run_id']"}},
+						},
+						{
+							"name":      "AIRFLOW_TASK_ID",
+							"valueFrom": map[string]any{"fieldRef": map[string]string{"fieldPath": "metadata.annotations['task_id']"}},
+						},
+						{
+							"name":      "AIRFLOW_DB_URL",
+							"valueFrom": map[string]any{"secretKeyRef": map[string]string{"name": "airflow-db", "key": "connection"}},
+						},
+					},
+					"resources": map[string]any{
+						"requests": map[string]string{
+							"cpu":    "200m",
+							"memory": "128Mi",
+						},
+					},
+					"volumeMounts": []map[string]any{
+						{
+							"mountPath": "/dags",
+							"name":      "dags-data",
+						},
+						{
+							"mountPath": "/etc/pki/tls/certs/ca-bundle.crt",
+							"name":      "ca-bundle-pem",
+							"readOnly":  true,
+							"subPath":   "ca-bundle.pem",
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/helm/airflow.go
+++ b/pkg/helm/airflow.go
@@ -61,7 +61,7 @@ func (c Client) createKnauditInitContainer(ctx context.Context) (map[string]any,
 					"volumeMounts": []map[string]any{
 						{
 							"mountPath": "/dags",
-							"name":      "dags-data",
+							"name":      "dags",
 						},
 						{
 							"mountPath": "/etc/pki/tls/certs/ca-bundle.crt",

--- a/pkg/helm/application.go
+++ b/pkg/helm/application.go
@@ -324,11 +324,6 @@ func parseTeamValue(key string, value any, values map[string]any) (any, error) {
 	}
 
 	keys := keySplitHandleEscape(key)
-
-	if pKeys, cKeys, idx, mutate := isMutation(keys); mutate {
-		return mutateGlobalListValue(pKeys, cKeys, idx, value, values)
-	}
-
 	value, err := ParseValue(value)
 	if err != nil {
 		return nil, err
@@ -336,73 +331,6 @@ func parseTeamValue(key string, value any, values map[string]any) (any, error) {
 	SetChartValue(keys, value, values)
 
 	return values, nil
-}
-
-func isMutation(keys []string) ([]string, string, int, bool) {
-	for i, p := range keys {
-		if idx, isListElement := isListElement(p); isListElement {
-			return keys[:i], strings.Join(keys[i+1:], "."), idx, true
-		}
-	}
-	return []string{}, "", 0, false
-}
-
-func isListElement(p string) (int, bool) {
-	if strings.HasPrefix(p, "[") && strings.HasSuffix(p, "]") {
-		v := strings.TrimPrefix(p, "[")
-		v = strings.TrimSuffix(v, "]")
-		idx, err := strconv.Atoi(v)
-		if err != nil {
-			return 0, false
-		}
-		return idx, true
-	}
-
-	return 0, false
-}
-
-func mutateGlobalListValue(pKeys []string, key string, idx int, value any, values map[string]any) (any, error) {
-	parentList := findParentList(pKeys, values)
-	value, err := ParseValue(value)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(parentList) == 0 {
-		parentList = append(parentList, map[string]any{})
-	}
-
-	if parent, ok := parentList[idx].(map[string]any); ok {
-		parent, err := parseTeamValue(key, value, parent)
-		if err != nil {
-			return nil, err
-		}
-
-		return parent, nil
-	}
-
-	parentList[idx] = value
-	return parentList[idx], nil
-}
-
-func findParentList(pKeys []string, values map[string]any) []any {
-	key := pKeys[0]
-
-	if len(pKeys) > 1 {
-		_, ok := values[key].(map[string]any)
-		if !ok {
-			values[key] = map[string]any{}
-		}
-
-		return findParentList(pKeys[1:], values[key].(map[string]any))
-	}
-
-	_, ok := values[key].([]any)
-	if !ok {
-		values[key] = []any{}
-	}
-
-	return values[key].([]any)
 }
 
 func mergeMaps(base, custom map[string]any) map[string]any {

--- a/pkg/helm/application.go
+++ b/pkg/helm/application.go
@@ -262,6 +262,15 @@ func (c Client) mergeValues(ctx context.Context, chartType gensql.ChartType, tea
 		return err
 	}
 
+	switch chartType {
+	case gensql.ChartTypeAirflow:
+		knauditInitContainer, err := c.createKnauditInitContainer(ctx)
+		if err != nil {
+			return err
+		}
+		mergeMaps(values, knauditInitContainer)
+	}
+
 	mergeMaps(defaultValues, values)
 	return nil
 }

--- a/pkg/helm/application_test.go
+++ b/pkg/helm/application_test.go
@@ -44,33 +44,6 @@ func Test_parseTeamValue(t *testing.T) {
 			want: map[string]any{"ingress": map[string]any{"web": map[string]any{"annotations": map[string]any{"kubernetes.io/ingress.allow-http": "true"}}}},
 		},
 		{
-			name: "Replace nested value test",
-			args: args{
-				key:    "webserver.extraContainers.[0].args",
-				value:  `["navikt/repo", "main", "/dags", "60"]`,
-				values: map[string]any{"webserver": map[string]any{"extraContainers": []any{map[string]any{"name": "hello"}}}},
-			},
-			want: map[string]any{"webserver": map[string]any{"extraContainers": []any{map[string]any{"name": "hello", "args": []any{"navikt/repo", "main", "/dags", "60"}}}}},
-		},
-		{
-			name: "Empty nested list",
-			args: args{
-				key:    "webserver.extraContainers.[0].args",
-				value:  `["navikt/repo", "main", "/dags", "60"]`,
-				values: map[string]any{"webserver": map[string]any{"extraContainers": []any{map[string]any{}}}},
-			},
-			want: map[string]any{"webserver": map[string]any{"extraContainers": []any{map[string]any{"args": []any{"navikt/repo", "main", "/dags", "60"}}}}},
-		},
-		{
-			name: "Replace nested value test single list element",
-			args: args{
-				key:    "webserver.extraContainers.[0].args.[0]",
-				value:  "navikt/repo",
-				values: map[string]any{"webserver": map[string]any{"extraContainers": []any{map[string]any{"name": "hello", "args": []any{"", "main", "/dags", "60"}}}}, "unaffected": "value"},
-			},
-			want: map[string]any{"webserver": map[string]any{"extraContainers": []any{map[string]any{"name": "hello", "args": []any{"navikt/repo", "main", "/dags", "60"}}}}, "unaffected": "value"},
-		},
-		{
 			name: "Handle omitted values",
 			args: args{
 				key:    "fernetKey,omit",


### PR DESCRIPTION
Endrer til å bruke git-sync fra chartet men overrider med vårt image og miljøvariabler for repo, branch, sync interval og destinasjonsmappe. Fjerner derfor alle `extraContainer/extraInitContainer` global values og team verdiene vi merger inn ved rollout (f.eks. `scheduler.extraContainers.[0].args.[0]` osv.).

Fjerner også knaudit initcontaineren fra global value da det eneste som trenger å være konfigurerbart der er imaget. Lar i stedet knorten hente knauditImage verdien fra databasen og bygge opp `extraInitContainer` objektet for workers ved rollout av airflow.